### PR TITLE
Chore/#14: 전역 폰트 설정 및 커스텀 색상 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
+    <link rel="stylesheet" href="./src/styles/tailwind.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,23 @@
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  font-family:
+    'Pretendard Variable',
+    Pretendard,
+    -apple-system,
+    BlinkMacSystemFont,
+    system-ui,
+    Roboto,
+    'Helvetica Neue',
+    'Segoe UI',
+    'Apple SD Gothic Neo',
+    'Noto Sans KR',
+    'Malgun Gothic',
+    'Apple Color Emoji',
+    'Segoe UI Emoji',
+    'Segoe UI Symbol',
+    sans-serif;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,22 @@
 export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: '#FFFCF8',
+        beige: {
+          primary: '#EBD8CB',
+          secondary: '#F1E3D9',
+          tertiary: '#FDF4ED',
+        },
+        brown: {
+          primary: '#613E29',
+          secondary: '#BC8462',
+          tertiary: '#DEBBA3',
+        },
+        pink: '#FF80A6',
+      },
+    },
   },
   plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,7 @@ export default {
   theme: {
     extend: {
       colors: {
-        background: '#FFFCF8',
+        background: '#FFFEFC',
         beige: {
           primary: '#EBD8CB',
           secondary: '#F1E3D9',


### PR DESCRIPTION
## 📌 관련 이슈
- #14 

## 🔑 주요 변경 사항
- 전역 폰트 설정을 추가하였습니다.
  - 전역 폰트로 Pretendard를 적용하였습니다. Tailwind CSS에서 폰트 적용 시 `font-weight`에 따라 클래스 이름에 `font-light`, `font-medium` 등의 속성만 작성하면 됩니다. (디폴트는 `font-normal`)

- 커스텀 색상을 다음과 같이 추가하였습니다.
  ```TypeScript
  colors: {
    background: '#FFFEFC',
    beige: {
      primary: '#EBD8CB',
      secondary: '#F1E3D9',
      tertiary: '#FDF4ED',
    },
    brown: {
      primary: '#613E29',
      secondary: '#BC8462',
      tertiary: '#DEBBA3',
    },
    pink: '#FF80A6',
  },
  ```
  - 색상은 각 계열별로 어두운 색상 → 밝은 색상 순서로 `primary`, `secondary`, `tertiary`로 지정하였습니다.
  - Tailwind CSS 기준으로 `bg-beige-secondary`와 같은 클래스 이름으로 적용할 수 있어요.

## 📖 참고 사항
- 브랜치를 `feature/#4`에서 분기하여 작업하였습니다. 해당 PR 병합 후, `feature/#4` 브랜치 병합하겠습니다!
