### PR TITLE
Fix/#21: BaseCardProps의 marketName 속성을 optional로 변경

### DIFF
--- a/src/types/Card.ts
+++ b/src/types/Card.ts
@@ -4,7 +4,7 @@ export type CardType = 'market' | 'product';
 
 export interface BaseCardProps {
   thumbnailUrl: string;
-  marketName: string;
+  marketName?: string;
   rate: number;
   reviewer: number;
   productName?: string;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #21 

## 🔑 주요 변경 사항
- `ProductCardProps`의 `marketName` 속성을 `optional`로 변경함에 따라, `BaseCardProps`의 `marketName` 속성도 `optional`로 수정했어요.

