### PR TITLE
Refactor/#29: 캐러셀 컴포넌트 리팩토링

### DIFF
--- a/src/components/Carousel/Carousel.stories.tsx
+++ b/src/components/Carousel/Carousel.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
 import Carousel from '@components/Carousel';
 import CarouselSlide from '@type/Carousel';
-import { mockSlides } from '@mocks/handlers';
+import MOCK_CAROUSEL_SLIDES from '@mocks/constants/mockCarouselSlides';
 import '@styles/tailwind.css';
 
 export default {
@@ -20,10 +20,10 @@ const Template: StoryFn<{ slides: CarouselSlide[] }> = (args) => (
 
 export const Default = Template.bind({});
 Default.args = {
-  slides: mockSlides,
+  slides: MOCK_CAROUSEL_SLIDES,
 };
 
 export const OnlyOneSlide = Template.bind({});
 OnlyOneSlide.args = {
-  slides: [mockSlides[0]],
+  slides: [MOCK_CAROUSEL_SLIDES[0]],
 };

--- a/src/components/Carousel/Carousel.test.tsx
+++ b/src/components/Carousel/Carousel.test.tsx
@@ -1,7 +1,10 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { MotionGlobalConfig } from 'framer-motion';
 import Carousel from '@components/Carousel';
 import MOCK_CAROUSEL_SLIDES from '@mocks/constants/mockCarouselSlides';
+
+MotionGlobalConfig.skipAnimations = true;
 
 describe('Carousel', () => {
   beforeEach(() => {
@@ -31,39 +34,38 @@ describe('Carousel', () => {
   it('5초 간격으로 슬라이드가 자동 재생된다.', async () => {
     render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
-    const images = screen.getAllByRole('img');
-    expect(images[1]).toHaveAttribute(
-      'src',
-      MOCK_CAROUSEL_SLIDES[0].thumbnailUrl,
-    );
+    const slideIndex = screen.getByTestId('carousel-slide-index');
 
     act(() => {
       vi.advanceTimersByTime(5000);
     });
 
-    const slideContainer = screen.getByRole('button').children[0];
-    expect(slideContainer).toHaveStyle({
-      transform: 'translateX(-200%)',
-    });
+    expect(slideIndex).toHaveTextContent('2');
   });
 
   it('스와이프 제스처가 올바르게 동작한다.', () => {
     render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const carouselElement = screen.getByRole('button');
+    const slideIndex = screen.getByTestId('carousel-slide-index');
+
+    fireEvent.mouseDown(carouselElement, { clientX: 200 });
+    fireEvent.mouseMove(carouselElement, { clientX: 50 });
+    fireEvent.mouseUp(carouselElement);
+
+    expect(slideIndex).toHaveTextContent('2');
 
     fireEvent.mouseDown(carouselElement, { clientX: 200 });
     fireEvent.mouseMove(carouselElement, { clientX: 350 });
     fireEvent.mouseUp(carouselElement);
 
-    const slideContainer = carouselElement.children[0];
-    expect(slideContainer).toHaveStyle({
-      transform: 'translateX(0%)',
-    });
+    expect(slideIndex).toHaveTextContent('1');
   });
 
   it('마지막 슬라이드 이후 첫 번째 슬라이드로 돌아간다.', () => {
     render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
+
+    const slideIndex = screen.getByTestId('carousel-slide-index');
 
     act(() => {
       vi.advanceTimersByTime(5000 * (MOCK_CAROUSEL_SLIDES.length - 1));
@@ -77,35 +79,28 @@ describe('Carousel', () => {
       vi.advanceTimersByTime(500);
     });
 
-    const slideContainer = screen.getByRole('button').children[0];
-    expect(slideContainer).toHaveStyle({
-      transform: 'translateX(-100%)',
-    });
+    expect(slideIndex).toHaveTextContent('1');
   });
 
   it('프로그레스 바가 올바르게 업데이트된다.', () => {
     render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
-    const progressBar = screen.getByRole('button').querySelector('.bg-pink');
+    const progressIndex = screen.getByTestId('carousel-progress-index');
 
-    expect(progressBar).toHaveStyle({
-      width: `${100 / MOCK_CAROUSEL_SLIDES.length}%`,
-      left: '0%',
-    });
+    expect(progressIndex).toHaveTextContent('0');
 
     act(() => {
       vi.advanceTimersByTime(5000);
     });
 
-    expect(progressBar).toHaveStyle({
-      left: `${100 / MOCK_CAROUSEL_SLIDES.length}%`,
-    });
+    expect(progressIndex).toHaveTextContent('1');
   });
 
   it('스와이프 중에는 자동 재생이 멈추고 스와이프가 끝나면 재개된다.', () => {
     render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const carouselElement = screen.getByRole('button');
+    const slideIndex = screen.getByTestId('carousel-slide-index');
 
     fireEvent.mouseDown(carouselElement, { clientX: 200 });
 
@@ -113,10 +108,7 @@ describe('Carousel', () => {
       vi.advanceTimersByTime(5000);
     });
 
-    const slideContainer = carouselElement.children[0];
-    expect(slideContainer).toHaveStyle({
-      transform: 'translateX(-100%)',
-    });
+    expect(slideIndex).toHaveTextContent('1');
 
     fireEvent.mouseUp(carouselElement);
 
@@ -124,8 +116,6 @@ describe('Carousel', () => {
       vi.advanceTimersByTime(5000);
     });
 
-    expect(slideContainer).toHaveStyle({
-      transform: 'translateX(-200%)',
-    });
+    expect(slideIndex).toHaveTextContent('2');
   });
 });

--- a/src/components/Carousel/Carousel.test.tsx
+++ b/src/components/Carousel/Carousel.test.tsx
@@ -25,7 +25,7 @@ describe('Carousel Hooks', () => {
       );
 
       expect(result.current.slideIndex).toBe(1);
-      expect(result.current.progressIndex).toBe(0);
+      expect(result.current.indicatorPosition).toBe(0);
       expect(result.current.slideAnimated).toBe(true);
     });
 
@@ -39,7 +39,7 @@ describe('Carousel Hooks', () => {
       });
 
       expect(result.current.slideIndex).toBe(2);
-      expect(result.current.progressIndex).toBe(1);
+      expect(result.current.indicatorPosition).toBe(1);
     });
 
     it('마지막 슬라이드에서 첫 슬라이드로 순환한다.', () => {
@@ -65,7 +65,7 @@ describe('Carousel Hooks', () => {
       });
 
       expect(result.current.slideIndex).toBe(1);
-      expect(result.current.progressIndex).toBe(0);
+      expect(result.current.indicatorPosition).toBe(0);
     });
   });
 

--- a/src/components/Carousel/Carousel.test.tsx
+++ b/src/components/Carousel/Carousel.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Carousel from '@components/Carousel';
-import { mockSlides } from '@mocks/handlers';
+import MOCK_CAROUSEL_SLIDES from '@mocks/constants/mockCarouselSlides';
 
 describe('Carousel', () => {
   beforeEach(() => {
@@ -13,20 +13,29 @@ describe('Carousel', () => {
   });
 
   it('모든 슬라이드가 올바르게 렌더링된다.', () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const images = screen.getAllByRole('img');
     expect(images).toHaveLength(7);
 
-    expect(images[0]).toHaveAttribute('src', mockSlides[4].thumbnailUrl);
-    expect(images[6]).toHaveAttribute('src', mockSlides[0].thumbnailUrl);
+    expect(images[0]).toHaveAttribute(
+      'src',
+      MOCK_CAROUSEL_SLIDES[4].thumbnailUrl,
+    );
+    expect(images[6]).toHaveAttribute(
+      'src',
+      MOCK_CAROUSEL_SLIDES[0].thumbnailUrl,
+    );
   });
 
   it('5초 간격으로 슬라이드가 자동 재생된다.', async () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const images = screen.getAllByRole('img');
-    expect(images[1]).toHaveAttribute('src', mockSlides[0].thumbnailUrl);
+    expect(images[1]).toHaveAttribute(
+      'src',
+      MOCK_CAROUSEL_SLIDES[0].thumbnailUrl,
+    );
 
     act(() => {
       vi.advanceTimersByTime(5000);
@@ -39,7 +48,7 @@ describe('Carousel', () => {
   });
 
   it('스와이프 제스처가 올바르게 동작한다.', () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const carouselElement = screen.getByRole('button');
 
@@ -54,10 +63,10 @@ describe('Carousel', () => {
   });
 
   it('마지막 슬라이드 이후 첫 번째 슬라이드로 돌아간다.', () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     act(() => {
-      vi.advanceTimersByTime(5000 * (mockSlides.length - 1));
+      vi.advanceTimersByTime(5000 * (MOCK_CAROUSEL_SLIDES.length - 1));
     });
 
     act(() => {
@@ -75,12 +84,12 @@ describe('Carousel', () => {
   });
 
   it('프로그레스 바가 올바르게 업데이트된다.', () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const progressBar = screen.getByRole('button').querySelector('.bg-pink');
 
     expect(progressBar).toHaveStyle({
-      width: `${100 / mockSlides.length}%`,
+      width: `${100 / MOCK_CAROUSEL_SLIDES.length}%`,
       left: '0%',
     });
 
@@ -89,12 +98,12 @@ describe('Carousel', () => {
     });
 
     expect(progressBar).toHaveStyle({
-      left: `${100 / mockSlides.length}%`,
+      left: `${100 / MOCK_CAROUSEL_SLIDES.length}%`,
     });
   });
 
   it('스와이프 중에는 자동 재생이 멈추고 스와이프가 끝나면 재개된다.', () => {
-    render(<Carousel slides={mockSlides} />);
+    render(<Carousel slides={MOCK_CAROUSEL_SLIDES} />);
 
     const carouselElement = screen.getByRole('button');
 

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -223,7 +223,7 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
 
   if (slides.length === 1) {
     return (
-      <div className="flex relative overflow-hidden aspect-[1.2] bg-beige-primary rounded-[10px]">
+      <div className="flex relative overflow-hidden aspect-[36/29] bg-beige-primary rounded-[10px]">
         <div className="flex h-full">
           <img
             src={slides[0].thumbnailUrl}
@@ -242,7 +242,7 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
 
   return (
     <div
-      className="flex relative overflow-hidden aspect-[1.2] bg-beige-primary rounded-[10px]"
+      className="flex relative overflow-hidden aspect-[36/29] bg-beige-primary rounded-[10px]"
       onMouseDown={handleStart}
       onTouchStart={handleStart}
       onMouseMove={handleSwipeMove}

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,22 +1,42 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import CarouselSlide from '@type/Carousel';
 
-const Carousel = ({ slides }: { slides: CarouselSlide[] }) => {
+interface ProgressBarProps {
+  progressIndex: number;
+  totalSlides: number;
+  animationDelay: number;
+}
+
+const SLIDE_DELAY_MS = 5000;
+const ANIMATION_DELAY_MS = 500;
+
+const useSlideSetup = (slides: CarouselSlide[]) => {
+  const displayedSlides = useMemo(() => {
+    if (slides.length === 0) return [];
+    return [
+      { ...slides[slides.length - 1], id: -1 },
+      ...slides,
+      { ...slides[0], id: 99 },
+    ];
+  }, [slides]);
+
+  return { displayedSlides };
+};
+
+const useCarouselState = (totalSlides: number) => {
   const [slideIndex, setSlideIndex] = useState(1);
   const [progressIndex, setProgressIndex] = useState(0);
-  const [isSwiping, setIsSwiping] = useState(false);
-  const [startX, setStartX] = useState(0);
-  const [swipeOffset, setSwipeOffset] = useState(0);
   const [slideAnimated, setSlideAnimated] = useState(true);
 
-  const autoSlideTimer = useRef<NodeJS.Timeout | null>(null);
-
-  const ANIMATION_DELAY_MS = 500;
-  const SLIDE_DELAY_MS = 5000;
-
   const goToNext = useCallback(() => {
-    if (slideIndex === slides.length) {
-      setSlideIndex(slides.length + 1);
+    if (slideIndex === totalSlides) {
+      setSlideIndex(totalSlides + 1);
       setTimeout(() => {
         setSlideAnimated(false);
         setSlideIndex(1);
@@ -26,21 +46,39 @@ const Carousel = ({ slides }: { slides: CarouselSlide[] }) => {
       setSlideAnimated(true);
       setSlideIndex((prev) => prev + 1);
     }
-  }, [slides.length, slideIndex]);
+  }, [totalSlides, slideIndex]);
 
-  const goToPrev = () => {
+  const goToPrev = useCallback(() => {
     if (slideIndex === 1) {
       setSlideIndex(0);
       setTimeout(() => {
         setSlideAnimated(false);
-        setSlideIndex(slides.length);
+        setSlideIndex(totalSlides);
       }, ANIMATION_DELAY_MS);
       setSlideAnimated(true);
     } else {
       setSlideAnimated(true);
       setSlideIndex((prev) => prev - 1);
     }
-  };
+  }, [totalSlides, slideIndex]);
+
+  useEffect(() => {
+    let newProgressIndex = slideIndex - 1;
+
+    if (slideIndex === 0) {
+      newProgressIndex = totalSlides - 1;
+    } else if (slideIndex === totalSlides + 1) {
+      newProgressIndex = 0;
+    }
+
+    setProgressIndex(newProgressIndex);
+  }, [slideIndex, totalSlides]);
+
+  return { slideIndex, progressIndex, slideAnimated, goToNext, goToPrev };
+};
+
+const useAutoSlide = (goToNext: () => void) => {
+  const autoSlideTimer = useRef<NodeJS.Timeout | null>(null);
 
   const resetTimer = useCallback(() => {
     if (autoSlideTimer.current) {
@@ -49,43 +87,15 @@ const Carousel = ({ slides }: { slides: CarouselSlide[] }) => {
     autoSlideTimer.current = setInterval(goToNext, SLIDE_DELAY_MS);
   }, [goToNext]);
 
-  const handleSwipeStart = (e: React.TouchEvent | React.MouseEvent) => {
-    setIsSwiping(true);
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
-    setStartX(clientX);
-
+  const pauseTimer = useCallback(() => {
     if (autoSlideTimer.current) {
       clearInterval(autoSlideTimer.current);
+      autoSlideTimer.current = null;
     }
-  };
-
-  const handleSwipeMove = (e: React.TouchEvent | React.MouseEvent) => {
-    if (!isSwiping) return;
-
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
-    const diff = clientX - startX;
-    setSwipeOffset(diff);
-  };
-
-  const handleSwipeEnd = () => {
-    if (!isSwiping) return;
-
-    if (Math.abs(swipeOffset) > 100) {
-      if (swipeOffset > 0) {
-        goToPrev();
-      } else {
-        goToNext();
-      }
-    }
-
-    setIsSwiping(false);
-    setSwipeOffset(0);
-    resetTimer();
-  };
+  }, []);
 
   useEffect(() => {
     resetTimer();
-
     return () => {
       if (autoSlideTimer.current) {
         clearInterval(autoSlideTimer.current);
@@ -93,65 +103,138 @@ const Carousel = ({ slides }: { slides: CarouselSlide[] }) => {
     };
   }, [resetTimer]);
 
-  useEffect(() => {
-    if (slideIndex === 0) {
-      setProgressIndex(slides.length - 1);
-    } else if (slideIndex === slides.length + 1) {
-      setProgressIndex(0);
-    } else {
-      setProgressIndex(slideIndex - 1);
-    }
-  }, [slideIndex, slides.length]);
+  return { resetTimer, pauseTimer };
+};
 
-  const translateX =
-    -(slideIndex * 100) + (swipeOffset / window.innerWidth) * 100;
+const useSlideSwipe = ({
+  goToNext,
+  goToPrev,
+}: {
+  goToNext: () => void;
+  goToPrev: () => void;
+}) => {
+  const [isSwiping, setIsSwiping] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [swipeOffset, setSwipeOffset] = useState(0);
 
-  const progressBarStyle = {
-    width: `${100 / slides.length}%`,
-    left: `${progressIndex * (100 / slides.length)}%`,
+  const handleSwipeStart = (e: React.TouchEvent | React.MouseEvent) => {
+    setIsSwiping(true);
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+    setStartX(clientX);
   };
 
-  const displayedSlides =
-    slides.length > 0
-      ? [
-          { ...slides[slides.length - 1], id: -1 },
-          ...slides,
-          { ...slides[0], id: 99 },
-        ]
-      : [];
+  const handleSwipeMove = (e: React.TouchEvent | React.MouseEvent) => {
+    if (!isSwiping) return;
+    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+    setSwipeOffset(clientX - startX);
+  };
+
+  const handleSwipeEnd = () => {
+    if (isSwiping && Math.abs(swipeOffset) > 100) {
+      if (swipeOffset > 0) {
+        goToPrev();
+      } else {
+        goToNext();
+      }
+    }
+    setIsSwiping(false);
+    setSwipeOffset(0);
+  };
+
+  return {
+    isSwiping,
+    swipeOffset,
+    handleSwipeStart,
+    handleSwipeMove,
+    handleSwipeEnd,
+  };
+};
+
+const SlideImage = ({ slide }: { slide: CarouselSlide }) => (
+  <div className="flex-shrink-0 w-full h-full">
+    <img
+      src={slide.thumbnailUrl}
+      alt="Carousel"
+      className="w-full h-full object-cover"
+      draggable={false}
+    />
+  </div>
+);
+
+const ProgressBar: React.FC<ProgressBarProps> = ({
+  progressIndex,
+  totalSlides,
+  animationDelay,
+}) => {
+  const progressBarStyle = {
+    width: `${100 / totalSlides}%`,
+    left: `${progressIndex * (100 / totalSlides)}%`,
+  };
+
+  return (
+    <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-[90%] h-[4px] bg-beige-secondary">
+      <div
+        className={`absolute h-[4px] bg-pink transition-all duration-${animationDelay} ease-out`}
+        style={progressBarStyle}
+      />
+    </div>
+  );
+};
+
+const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
+  const { displayedSlides } = useSlideSetup(slides);
+  const { slideIndex, progressIndex, slideAnimated, goToNext, goToPrev } =
+    useCarouselState(slides.length);
+  const {
+    isSwiping,
+    swipeOffset,
+    handleSwipeStart,
+    handleSwipeMove,
+    handleSwipeEnd,
+  } = useSlideSwipe({ goToNext, goToPrev });
+  const { resetTimer, pauseTimer } = useAutoSlide(goToNext);
+
+  const translateX = useMemo(
+    () => -100 * slideIndex + (swipeOffset / window.innerWidth) * 100,
+    [slideIndex, swipeOffset],
+  );
+
+  const handleStart = (e: React.TouchEvent | React.MouseEvent) => {
+    handleSwipeStart(e);
+    pauseTimer();
+  };
+
+  const handleEnd = () => {
+    handleSwipeEnd();
+    resetTimer();
+  };
 
   if (slides.length === 1) {
     return (
-      <div
-        className="relative overflow-hidden w-[358px] h-[292px] bg-beige-primary rounded-[8px]"
-        role="button"
-        tabIndex={0}
-      >
+      <div className="flex relative overflow-hidden aspect-[1.2] bg-beige-primary rounded-[10px]">
         <div className="flex h-full">
-          <div className="flex-shrink-0 w-full h-full">
-            <img
-              src={slides[0].thumbnailUrl}
-              alt="Carousel 1"
-              className="w-full h-full object-cover"
-              draggable="false"
-            />
-          </div>
+          <img
+            src={slides[0].thumbnailUrl}
+            alt="Carousel"
+            className="w-full h-full object-cover"
+            draggable={false}
+          />
         </div>
-        <div className="absolute inset-0 w-full h-full border-beige-secondary border-4 rounded-[8px]" />
+        <div className="absolute inset-0 w-full h-full border-beige-secondary border-4 rounded-[10px]" />
       </div>
     );
   }
 
   return (
     <div
-      className="relative overflow-hidden w-[358px] h-[292px] bg-beige-primary rounded-[8px]"
-      onMouseDown={handleSwipeStart}
-      onTouchStart={handleSwipeStart}
+      className="flex relative overflow-hidden aspect-[1.2] bg-beige-primary rounded-[10px]"
+      onMouseDown={handleStart}
+      onTouchStart={handleStart}
       onMouseMove={handleSwipeMove}
       onTouchMove={handleSwipeMove}
-      onMouseUp={handleSwipeEnd}
-      onTouchEnd={handleSwipeEnd}
-      onMouseLeave={handleSwipeEnd}
+      onMouseUp={handleEnd}
+      onTouchEnd={handleEnd}
+      onMouseLeave={handleEnd}
       role="button"
       tabIndex={0}
     >
@@ -163,26 +246,16 @@ const Carousel = ({ slides }: { slides: CarouselSlide[] }) => {
             isSwiping || !slideAnimated ? 'none' : 'transform',
         }}
       >
-        {displayedSlides.map((slide, index) => {
-          return (
-            <div key={slide.id} className="flex-shrink-0 w-full h-full">
-              <img
-                src={slide.thumbnailUrl}
-                alt={`Carousel ${index + 1}`}
-                className="w-full h-full object-cover"
-                draggable="false"
-              />
-            </div>
-          );
-        })}
+        {displayedSlides.map((slide) => (
+          <SlideImage key={slide.id} slide={slide} />
+        ))}
       </div>
-      <div className="absolute inset-0 w-full h-full border-beige-secondary border-[4px] rounded-[8px]" />
-      <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-[90%] h-[4px] bg-beige-secondary">
-        <div
-          className={`absolute h-[4px] bg-pink transition-all duration-${ANIMATION_DELAY_MS} ease-out`}
-          style={progressBarStyle}
-        />
-      </div>
+      <div className="absolute inset-0 w-full h-full border-beige-secondary border-[4px] rounded-[10px]" />
+      <ProgressBar
+        progressIndex={progressIndex}
+        totalSlides={slides.length}
+        animationDelay={ANIMATION_DELAY_MS}
+      />
     </div>
   );
 };

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -233,6 +233,9 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
           />
         </div>
         <div className="absolute inset-0 w-full h-full border-beige-secondary border-4 rounded-[10px]" />
+        <div className="hidden" data-testid="carousel-slide-index">
+          {slideIndex}
+        </div>
       </div>
     );
   }
@@ -271,6 +274,12 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
         totalSlides={slides.length}
         animationDelay={ANIMATION_DELAY_MS}
       />
+      <div className="hidden" data-testid="carousel-slide-index">
+        {slideIndex}
+      </div>
+      <div className="hidden" data-testid="carousel-progress-index">
+        {progressIndex}
+      </div>
     </div>
   );
 };

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -8,8 +8,8 @@ import React, {
 import { motion } from 'framer-motion';
 import CarouselSlide from '@type/Carousel';
 
-interface ProgressBarProps {
-  progressIndex: number;
+interface IndicatorProps {
+  indicatorPosition: number;
   totalSlides: number;
   animationDelay: number;
 }
@@ -32,8 +32,9 @@ const useSlideSetup = (slides: CarouselSlide[]) => {
 
 export const useCarouselState = (totalSlides: number) => {
   const [slideIndex, setSlideIndex] = useState(1);
-  const [progressIndex, setProgressIndex] = useState(0);
   const [slideAnimated, setSlideAnimated] = useState(true);
+
+  const indicatorPosition = (slideIndex + totalSlides - 1) % totalSlides;
 
   const goToNext = useCallback(() => {
     if (slideIndex === totalSlides) {
@@ -63,19 +64,7 @@ export const useCarouselState = (totalSlides: number) => {
     }
   }, [totalSlides, slideIndex]);
 
-  useEffect(() => {
-    let newProgressIndex = slideIndex - 1;
-
-    if (slideIndex === 0) {
-      newProgressIndex = totalSlides - 1;
-    } else if (slideIndex === totalSlides + 1) {
-      newProgressIndex = 0;
-    }
-
-    setProgressIndex(newProgressIndex);
-  }, [slideIndex, totalSlides]);
-
-  return { slideIndex, progressIndex, slideAnimated, goToNext, goToPrev };
+  return { slideIndex, indicatorPosition, slideAnimated, goToNext, goToPrev };
 };
 
 export const useAutoSlide = (goToNext: () => void) => {
@@ -168,8 +157,8 @@ const SlideImage = ({ slide }: { slide: CarouselSlide }) => (
   </div>
 );
 
-const ProgressBar: React.FC<ProgressBarProps> = ({
-  progressIndex,
+const Indicator: React.FC<IndicatorProps> = ({
+  indicatorPosition,
   totalSlides,
   animationDelay,
 }) => {
@@ -181,7 +170,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
         className="absolute h-[4px] bg-pink"
         initial={false}
         animate={{
-          left: `${progressIndex * width}%`,
+          left: `${indicatorPosition * width}%`,
           width: `${width}%`,
         }}
         transition={{
@@ -195,7 +184,7 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
 
 const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
   const { displayedSlides } = useSlideSetup(slides);
-  const { slideIndex, progressIndex, slideAnimated, goToNext, goToPrev } =
+  const { slideIndex, indicatorPosition, slideAnimated, goToNext, goToPrev } =
     useCarouselState(slides.length);
   const {
     isSwiping,
@@ -266,8 +255,8 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
         ))}
       </motion.div>
       <div className="absolute inset-0 w-full h-full border-beige-secondary border-[4px] rounded-[10px]" />
-      <ProgressBar
-        progressIndex={progressIndex}
+      <Indicator
+        indicatorPosition={indicatorPosition}
         totalSlides={slides.length}
         animationDelay={ANIMATION_DELAY_MS}
       />

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -5,6 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { motion } from 'framer-motion';
 import CarouselSlide from '@type/Carousel';
 
 interface ProgressBarProps {
@@ -172,16 +173,21 @@ const ProgressBar: React.FC<ProgressBarProps> = ({
   totalSlides,
   animationDelay,
 }) => {
-  const progressBarStyle = {
-    width: `${100 / totalSlides}%`,
-    left: `${progressIndex * (100 / totalSlides)}%`,
-  };
+  const width = 100 / totalSlides;
 
   return (
-    <div className="absolute bottom-0 left-1/2 transform -translate-x-1/2 w-[90%] h-[4px] bg-beige-secondary">
-      <div
-        className={`absolute h-[4px] bg-pink transition-all duration-${animationDelay} ease-out`}
-        style={progressBarStyle}
+    <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-[90%] h-[4px] bg-beige-secondary">
+      <motion.div
+        className="absolute h-[4px] bg-pink"
+        initial={false}
+        animate={{
+          left: `${progressIndex * width}%`,
+          width: `${width}%`,
+        }}
+        transition={{
+          duration: animationDelay / 1000,
+          ease: 'easeOut',
+        }}
       />
     </div>
   );
@@ -244,18 +250,21 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
       role="button"
       tabIndex={0}
     >
-      <div
-        className={`flex h-full transition-transform duration-${ANIMATION_DELAY_MS} ease-out`}
-        style={{
-          transform: `translateX(${translateX}%)`,
-          transitionProperty:
-            isSwiping || !slideAnimated ? 'none' : 'transform',
+      <motion.div
+        className="flex h-full"
+        initial={false}
+        animate={{
+          x: `${translateX}%`,
+        }}
+        transition={{
+          duration: isSwiping || !slideAnimated ? 0 : ANIMATION_DELAY_MS / 1000,
+          ease: 'easeOut',
         }}
       >
         {displayedSlides.map((slide) => (
           <SlideImage key={slide.id} slide={slide} />
         ))}
-      </div>
+      </motion.div>
       <div className="absolute inset-0 w-full h-full border-beige-secondary border-[4px] rounded-[10px]" />
       <ProgressBar
         progressIndex={progressIndex}

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -117,19 +117,25 @@ const useSlideSwipe = ({
   const [startX, setStartX] = useState(0);
   const [swipeOffset, setSwipeOffset] = useState(0);
 
-  const handleSwipeStart = (e: React.TouchEvent | React.MouseEvent) => {
-    setIsSwiping(true);
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
-    setStartX(clientX);
-  };
+  const handleSwipeStart = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      setIsSwiping(true);
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      setStartX(clientX);
+    },
+    [],
+  );
 
-  const handleSwipeMove = (e: React.TouchEvent | React.MouseEvent) => {
-    if (!isSwiping) return;
-    const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
-    setSwipeOffset(clientX - startX);
-  };
+  const handleSwipeMove = useCallback(
+    (e: React.TouchEvent | React.MouseEvent) => {
+      if (!isSwiping) return;
+      const clientX = 'touches' in e ? e.touches[0].clientX : e.clientX;
+      setSwipeOffset(clientX - startX);
+    },
+    [isSwiping, startX],
+  );
 
-  const handleSwipeEnd = () => {
+  const handleSwipeEnd = useCallback(() => {
     if (isSwiping && Math.abs(swipeOffset) > 100) {
       if (swipeOffset > 0) {
         goToPrev();
@@ -139,7 +145,7 @@ const useSlideSwipe = ({
     }
     setIsSwiping(false);
     setSwipeOffset(0);
-  };
+  }, [isSwiping, swipeOffset]);
 
   return {
     isSwiping,

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -30,7 +30,7 @@ const useSlideSetup = (slides: CarouselSlide[]) => {
   return { displayedSlides };
 };
 
-const useCarouselState = (totalSlides: number) => {
+export const useCarouselState = (totalSlides: number) => {
   const [slideIndex, setSlideIndex] = useState(1);
   const [progressIndex, setProgressIndex] = useState(0);
   const [slideAnimated, setSlideAnimated] = useState(true);
@@ -78,7 +78,7 @@ const useCarouselState = (totalSlides: number) => {
   return { slideIndex, progressIndex, slideAnimated, goToNext, goToPrev };
 };
 
-const useAutoSlide = (goToNext: () => void) => {
+export const useAutoSlide = (goToNext: () => void) => {
   const autoSlideTimer = useRef<NodeJS.Timeout | null>(null);
 
   const resetTimer = useCallback(() => {
@@ -107,7 +107,7 @@ const useAutoSlide = (goToNext: () => void) => {
   return { resetTimer, pauseTimer };
 };
 
-const useSlideSwipe = ({
+export const useSlideSwipe = ({
   goToNext,
   goToPrev,
 }: {
@@ -233,9 +233,6 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
           />
         </div>
         <div className="absolute inset-0 w-full h-full border-beige-secondary border-4 rounded-[10px]" />
-        <div className="hidden" data-testid="carousel-slide-index">
-          {slideIndex}
-        </div>
       </div>
     );
   }
@@ -274,12 +271,6 @@ const Carousel: React.FC<{ slides: CarouselSlide[] }> = ({ slides }) => {
         totalSlides={slides.length}
         animationDelay={ANIMATION_DELAY_MS}
       />
-      <div className="hidden" data-testid="carousel-slide-index">
-        {slideIndex}
-      </div>
-      <div className="hidden" data-testid="carousel-progress-index">
-        {progressIndex}
-      </div>
     </div>
   );
 };

--- a/src/mocks/constants/mockCarouselSlides.ts
+++ b/src/mocks/constants/mockCarouselSlides.ts
@@ -1,0 +1,29 @@
+const MOCK_CAROUSEL_SLIDES = [
+  {
+    id: 0,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1452968011964-24f8831c43c3?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    id: 1,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1541781550486-81b7a2328578?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    id: 2,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1581343659198-abab39bb36aa?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    id: 3,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1713274783669-631543642a61?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+  {
+    id: 4,
+    thumbnailUrl:
+      'https://images.unsplash.com/photo-1566760375903-061dfd31c175?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  },
+];
+
+export default MOCK_CAROUSEL_SLIDES;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,36 +1,9 @@
 import { http } from 'msw';
-
-export const mockSlides = [
-  {
-    id: 0,
-    thumbnailUrl:
-      'https://images.unsplash.com/photo-1452968011964-24f8831c43c3?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 1,
-    thumbnailUrl:
-      'https://images.unsplash.com/photo-1541781550486-81b7a2328578?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 2,
-    thumbnailUrl:
-      'https://images.unsplash.com/photo-1581343659198-abab39bb36aa?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 3,
-    thumbnailUrl:
-      'https://images.unsplash.com/photo-1713274783669-631543642a61?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-  {
-    id: 4,
-    thumbnailUrl:
-      'https://images.unsplash.com/photo-1566760375903-061dfd31c175?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-  },
-];
+import MOCK_CAROUSEL_SLIDES from '@mocks/constants/mockCarouselSlides';
 
 const handlers = [
   http.get('/api/carousel', () => {
-    return new Response(JSON.stringify(mockSlides), { status: 200 });
+    return new Response(JSON.stringify(MOCK_CAROUSEL_SLIDES), { status: 200 });
   }),
 ];
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #29 
 
## 🔑 주요 변경 사항
- 기존 `Carousel` 컴포넌트 내 존재했던 다양한 로직들을 커스텀 훅으로 분리하여 코드 가독성 및 유지보수성을 개선했습니다.

  - `useAutoSlide`: 자동 슬라이드 타이머 관리 로직을 분리하여, 타이머 초기화 및 정지 기능을 담당하는 훅을 작성했습니다.

  - `useCarouselState`: 슬라이드 인덱스 및 진행 상태를 관리하는 로직을 분리하여, 슬라이드 상태 관리 기능을 전담하는 훅을 작성했습니다.

  - `useSlideSwipe`: 캐러셀 스와이프 이벤트 처리 로직도 별도의 훅으로 분리하여, 스와이프 시작, 이동, 종료를 처리하는 기능을 독립적으로 관리할 수 있도록 했습니다.

  - `useSlideSetup`: 슬라이드 데이터 설정 및 화면에 표시할 슬라이드를 설정하는 로직을 분리했습니다.

- 슬라이드 이미지 렌더링과 진행 상태 표시를 위한 `SlideImage`와 `ProgressBar` 컴포넌트를 각각 독립적인 컴포넌트로 분리했습니다.

-  성능 최적화

    - `displayedSlides`와 `translateX` 값 계산을 메모이제이션하여, 슬라이드 인덱스나 스와이프 이동이 있을 때만 필요한 계산을 수행하도록 했습니다.
  
    - 슬라이드 인덱스 변경, 타이머 리셋, 스와이프 핸들러 같은 함수들을 메모이제이션하여 불필요한 함수 재생성을 방지했습니다.

- `framer-motion` 적용

  - 기존 적용된 애니메이션 효과를 `framer-motion`으로 대체했습니다.

  - `framer-motion` 적용 시 `style` 속성을 직접 비교하는 방식의 테스트는 적용하기 어려워, 커스텀 훅을 개별적으로 테스트하는 방식으로 변경했습니다.

## 💬 TO REVIEWERS
- 테스트 코드 작성이 아직 익숙지 않긴 하지만, 단위 테스트 관점에서는 오히려 변경된 방식의 테스트가 더 적합하지 않나 싶습니다. 기존의 테스트는 UI와 상호작용 및 DOM을 포함한 종합적인 검증을 하고 있는데, 이 부분은 통합 테스트에서 다루는 게 더 좋을 것 같아요. (테스트 코드 작성도 이렇게 하는 편이 더 편리할 것 같구요!)
- 인터넷에서 찾아보니 테스트 코드를 처음 작성하면서 저와 같은 시행착오를 겪는 사람들이 많은 것 같아요😭 이 부분은 같이 고민해 보면 좋을 것 같아요. (https://suzyalrahala.tistory.com/m/93 테스트 작성에 대한 생각을 정리하는 데 도움이 될 것 같아 공유드려요!)