### PR TITLE
Fix/#31: 탭 내비게이터 테스트 오류 수정

### DIFF
--- a/src/components/TabNavigator/TabNavigator.test.tsx
+++ b/src/components/TabNavigator/TabNavigator.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import TabNavigator from '@components/TabNavigator';
-import { filterTabs, HEADER_TABS } from '@components/TabNavigator/tabs';
+import { HEADER_TABS } from '@components/TabNavigator/tabs';
+import MOCK_TABS from '@mocks/constants/mockTabs';
 
 describe('TabNavigator Component', () => {
   it('탭이 정상적으로 렌더링되는지 확인', () => {
@@ -49,14 +50,16 @@ describe('TabNavigator Component', () => {
     expect(fondantTab).toHaveClass('text-pink');
   });
 
-  it('하단 인디케이터(Framer Motion)가 선택된 탭으로 이동하는지 확인', () => {
+  it('하단 인디케이터가 선택된 탭으로 이동하는지 확인', () => {
     render(<TabNavigator tabs={HEADER_TABS} />);
 
     const discountTab = screen.getByText('할인');
     fireEvent.click(discountTab);
 
     const indicator = screen.getByTestId('tab-indicator');
-    expect(indicator).toBeInTheDocument();
+    const parentButton = indicator.closest('button');
+
+    expect(parentButton).toHaveTextContent('할인');
   });
 
   it('기본 텍스트 설정 시, 선택된 탭만 +2px 되는지 확인', () => {
@@ -75,18 +78,18 @@ describe('TabNavigator Component', () => {
   });
 
   it('탭의 타입이 "inner"이면 글씨 굵기가 고정되는지 확인', () => {
-    render(<TabNavigator tabs={filterTabs} type="inner" />);
+    render(<TabNavigator tabs={MOCK_TABS} type="inner" />);
 
-    filterTabs.forEach((tab) => {
+    MOCK_TABS.forEach((tab) => {
       const tabElement = screen.getByText(tab.label);
       expect(tabElement).toHaveClass('font-normal');
     });
   });
 
   it('고정된 텍스트 크기 설정 시, 크기가 변하지 않는지 확인', () => {
-    render(<TabNavigator tabs={filterTabs} fixedTextSize={13} />);
+    render(<TabNavigator tabs={MOCK_TABS} fixedTextSize={13} />);
 
-    filterTabs.forEach((tab) => {
+    MOCK_TABS.forEach((tab) => {
       const tabElement = screen.getByText(tab.label);
       expect(tabElement).toHaveStyle({ fontSize: '13px' });
     });


### PR DESCRIPTION
## 📌 관련 이슈
- closes #31 

## 🔑 주요 변경 사항
- 하단 인디케이터 검증 수정
  - 기존 테스트에서 인디케이터의 존재 여부만 검증하고 있었던 부분을, 인디케이터가 선택된 탭에 정확히 이동하는지 확인할 수 있도록 수정했습니다. `indicator`의 부모 `button` 요소를 찾아, 버튼의 텍스트가 선택된 탭과 일치하는지 확인합니다.

- mock 데이터 경로 수정
  - 테스트에서 mock 데이터의 경로가 잘못 `import`되는 문제가 있었습니다. 이를 수정하여 `MOCK_TABS`를 올바르게 사용하도록 변경했습니다.