### PR TITLE
Feature/#39: 체크 버튼, 라디오 버튼 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,7 +52,8 @@
     "@typescript-eslint/lines-between-class-members": "off",
     "@typescript-eslint/no-throw-literal": "off",
     "react/prop-types": "off",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "react/require-default-props": "off"
   },
   "ignorePatterns": ["build", "dist", "public"],
   "overrides": [

--- a/src/assets/icons/check.svg
+++ b/src/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.1665 7.9585L9.08317 15.0418L5.5415 11.5002" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/CheckButton/CheckButton.stories.tsx
+++ b/src/components/CheckButton/CheckButton.stories.tsx
@@ -22,6 +22,14 @@ export default {
     },
     onClick: { description: '버튼이 클릭되었을 때 호출되는 콜백 함수입니다.' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '여러 옵션을 선택할 수 있는 체크 버튼 컴포넌트입니다.',
+      },
+    },
+  },
 } as Meta;
 
 export const Default = {

--- a/src/components/CheckButton/CheckButton.stories.tsx
+++ b/src/components/CheckButton/CheckButton.stories.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { Meta } from '@storybook/react';
+import CheckButton from '@components/CheckButton';
+import '@styles/tailwind.css';
+
+export default {
+  title: 'Components/CheckButton',
+  component: CheckButton,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      description: '버튼의 크기를 설정합니다.',
+      control: { type: 'number', min: 16, max: 28, step: 2 },
+    },
+    rounded: {
+      description: '버튼의 모서리가 둥근지 여부를 결정합니다.',
+      control: 'boolean',
+    },
+    selected: {
+      description: '버튼이 선택된 상태인지 여부를 설정합니다.',
+      control: 'boolean',
+    },
+    onClick: { description: '버튼이 클릭되었을 때 호출되는 콜백 함수입니다.' },
+  },
+} as Meta;
+
+export const Default = {
+  args: {
+    rounded: false,
+    selected: false,
+  },
+};
+
+export const Selected = {
+  args: {
+    rounded: false,
+    selected: true,
+  },
+};
+
+export const Rounded = {
+  args: {
+    rounded: true,
+    selected: false,
+  },
+};
+
+export const RoundedSelected = {
+  args: {
+    rounded: true,
+    selected: true,
+  },
+};
+
+export const CheckButtonGroupExample = {
+  render: () => {
+    const [selectedOptions, setSelectedOptions] = useState<number[]>([]);
+
+    const options = [
+      { id: 1, label: '옵션 1' },
+      { id: 2, label: '옵션 2' },
+      { id: 3, label: '옵션 3' },
+    ];
+
+    const handleToggle = (id: number) => {
+      setSelectedOptions((prevSelected) => {
+        if (prevSelected.includes(id)) {
+          return prevSelected.filter((optionId) => optionId !== id);
+        }
+        return [...prevSelected, id];
+      });
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent, id: number) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleToggle(id);
+      }
+    };
+
+    return (
+      <div className="flex flex-col gap-[10px]">
+        {options.map((option) => (
+          <div
+            key={option.id}
+            className="flex items-center gap-[10px] cursor-pointer"
+          >
+            <CheckButton
+              selected={selectedOptions.includes(option.id)}
+              onClick={() => handleToggle(option.id)}
+            />
+            <span
+              onClick={() => handleToggle(option.id)}
+              onKeyDown={(e) => handleKeyDown(e, option.id)}
+              tabIndex={0}
+              role="button"
+            >
+              {option.label}
+            </span>
+          </div>
+        ))}
+        <span className="font-semibold">
+          선택한 옵션: {selectedOptions.join(', ')}
+        </span>
+      </div>
+    );
+  },
+};

--- a/src/components/CheckButton/CheckButton.test.tsx
+++ b/src/components/CheckButton/CheckButton.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CheckButton from '@components/CheckButton';
+
+describe('CheckButton', () => {
+  it('선택되지 않은 상태를 올바르게 렌더링한다.', () => {
+    render(<CheckButton selected={false} />);
+
+    const checkButton = screen.getByRole('checkbox');
+    expect(checkButton).toBeInTheDocument();
+    expect(checkButton).toHaveAttribute('aria-checked', 'false');
+
+    const checkIcon = checkButton.querySelector('svg');
+    expect(checkIcon).not.toBeInTheDocument();
+  });
+
+  it('선택된 상태를 올바르게 렌더링한다.', () => {
+    render(<CheckButton selected />);
+
+    const checkButton = screen.getByRole('checkbox');
+    expect(checkButton).toBeInTheDocument();
+    expect(checkButton).toHaveAttribute('aria-checked', 'true');
+
+    const checkIcon = checkButton.querySelector('svg');
+    expect(checkIcon).toBeInTheDocument();
+  });
+
+  it('클릭 시 onClick 함수가 호출된다.', () => {
+    const handleClick = vi.fn();
+    render(<CheckButton selected={false} onClick={handleClick} />);
+
+    const checkButton = screen.getByRole('checkbox');
+    fireEvent.click(checkButton);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter 키를 눌렀을 때 onClick 함수가 호출된다.', () => {
+    const handleClick = vi.fn();
+    render(<CheckButton selected={false} onClick={handleClick} />);
+
+    const checkButton = screen.getByRole('checkbox');
+    fireEvent.keyDown(checkButton, { key: 'Enter' });
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('올바른 크기가 적용된다.', () => {
+    const size = 30;
+    render(<CheckButton selected={false} size={size} />);
+
+    const checkButton = screen.getByRole('checkbox');
+    expect(checkButton).toHaveStyle(`width: ${size}px`);
+    expect(checkButton).toHaveStyle(`height: ${size}px`);
+  });
+
+  it('rounded가 true일 때 둥근 모서리가 적용된다.', () => {
+    render(<CheckButton selected={false} rounded />);
+
+    const checkButton = screen.getByRole('checkbox');
+    expect(checkButton).toHaveClass('rounded-full');
+  });
+
+  it('rounded가 false일 때 각진 모서리가 적용된다.', () => {
+    render(<CheckButton selected={false} rounded={false} />);
+
+    const checkButton = screen.getByRole('checkbox');
+    expect(checkButton).toHaveClass('rounded-[3px]');
+  });
+});

--- a/src/components/CheckButton/index.tsx
+++ b/src/components/CheckButton/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import CheckIcon from '@assets/icons/check.svg?react';
+
+interface CheckButtonProps {
+  size?: number;
+  rounded?: boolean;
+  selected: boolean;
+  onClick?: () => void;
+}
+
+const CheckButton: React.FC<CheckButtonProps> = ({
+  size = 22,
+  rounded = false,
+  selected,
+  onClick,
+}) => {
+  const radiusClass = rounded ? 'rounded-full' : 'rounded-[3px]';
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onClick?.();
+    }
+  };
+
+  return selected ? (
+    <div
+      role="checkbox"
+      aria-checked={selected}
+      aria-label={selected ? 'selected' : 'unselected'}
+      tabIndex={0}
+      className={`flex items-center justify-center bg-pink ${radiusClass} cursor-pointer`}
+      style={{ width: size, height: size }}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+    >
+      <CheckIcon width={size} height={size} />
+    </div>
+  ) : (
+    <div
+      role="checkbox"
+      aria-checked={selected}
+      aria-label={selected ? 'selected' : 'unselected'}
+      tabIndex={0}
+      className={`border-[2px] border-beige-primary ${radiusClass} cursor-pointer`}
+      style={{ width: size, height: size }}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+export default CheckButton;

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { Meta } from '@storybook/react';
+import RadioButton from '@components/RadioButton';
+import '@styles/tailwind.css';
+
+export default {
+  title: 'Components/RadioButton',
+  component: RadioButton,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      description: '버튼의 크기를 설정합니다.',
+      control: { type: 'number', min: 16, max: 28, step: 2 },
+    },
+    selected: {
+      description: '버튼이 선택된 상태인지 여부를 설정합니다.',
+      control: 'boolean',
+    },
+    onClick: { description: '버튼이 클릭되었을 때 호출되는 콜백 함수입니다.' },
+  },
+} as Meta;
+
+export const Default = {
+  args: {
+    selected: false,
+  },
+};
+
+export const Selected = {
+  args: {
+    selected: true,
+  },
+};
+
+export const RadioButtonGroupExample = {
+  render: () => {
+    const [selectedOption, setSelectedOption] = useState<number>(0);
+
+    const options = [
+      { id: 1, label: '옵션 1' },
+      { id: 2, label: '옵션 2' },
+      { id: 3, label: '옵션 3' },
+    ];
+
+    const handleOptionSelect = (id: number) => {
+      setSelectedOption(id);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent, id: number) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleOptionSelect(id);
+      }
+    };
+
+    return (
+      <div
+        role="radiogroup"
+        aria-label="option-select"
+        className="flex flex-col gap-[10px]"
+      >
+        {options.map((option) => (
+          <div
+            key={option.id}
+            className="flex items-center gap-[10px] cursor-pointer"
+          >
+            <RadioButton
+              selected={selectedOption === option.id}
+              onClick={() => handleOptionSelect(option.id)}
+            />
+            <span
+              onClick={() => handleOptionSelect(option.id)}
+              onKeyDown={(e) => handleKeyDown(e, option.id)}
+              tabIndex={0}
+              role="button"
+            >
+              {option.label}
+            </span>
+          </div>
+        ))}
+        <span className="font-semibold">선택한 옵션: {selectedOption}</span>
+      </div>
+    );
+  },
+};

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -18,6 +18,14 @@ export default {
     },
     onClick: { description: '버튼이 클릭되었을 때 호출되는 콜백 함수입니다.' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '단일 옵션을 선택할 수 있는 라디오 버튼 컴포넌트입니다.',
+      },
+    },
+  },
 } as Meta;
 
 export const Default = {

--- a/src/components/RadioButton/RadioButton.test.tsx
+++ b/src/components/RadioButton/RadioButton.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RadioButton from '@components/RadioButton';
+
+describe('RadioButton', () => {
+  it('선택되지 않은 상태를 올바르게 렌더링한다.', () => {
+    render(<RadioButton selected={false} />);
+
+    const radioButton = screen.getByRole('radio');
+    expect(radioButton).toBeInTheDocument();
+    expect(radioButton).toHaveAttribute('aria-checked', 'false');
+
+    const innerCircle = radioButton.querySelector('div');
+    expect(innerCircle).not.toBeInTheDocument();
+  });
+
+  it('선택된 상태를 올바르게 렌더링한다.', () => {
+    render(<RadioButton selected />);
+
+    const radioButton = screen.getByRole('radio');
+    expect(radioButton).toBeInTheDocument();
+    expect(radioButton).toHaveAttribute('aria-checked', 'true');
+
+    const innerCircle = radioButton.querySelector('div');
+    expect(innerCircle).toBeInTheDocument();
+  });
+
+  it('클릭 시 onClick 함수가 호출된다.', () => {
+    const handleClick = vi.fn();
+    render(<RadioButton selected={false} onClick={handleClick} />);
+
+    const radioButton = screen.getByRole('radio');
+    fireEvent.click(radioButton);
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter 키를 눌렀을 때 onClick 함수가 호출된다.', () => {
+    const handleClick = vi.fn();
+    render(<RadioButton selected={false} onClick={handleClick} />);
+
+    const radioButton = screen.getByRole('radio');
+    fireEvent.keyDown(radioButton, { key: 'Enter' });
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('올바른 크기가 적용된다.', () => {
+    const size = 30;
+    render(<RadioButton selected={false} size={size} />);
+
+    const radioButton = screen.getByRole('radio');
+    expect(radioButton).toHaveStyle(`width: ${size}px`);
+    expect(radioButton).toHaveStyle(`height: ${size}px`);
+  });
+});

--- a/src/components/RadioButton/index.tsx
+++ b/src/components/RadioButton/index.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+interface RadioButtonProps {
+  size?: number;
+  selected: boolean;
+  onClick?: () => void;
+}
+
+const RadioButton: React.FC<RadioButtonProps> = ({
+  size = 22,
+  selected,
+  onClick,
+}) => {
+  const innerCircleSize = Math.floor(size * 0.5);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      onClick?.();
+    }
+  };
+
+  return (
+    <div
+      role="radio"
+      aria-checked={selected}
+      tabIndex={0}
+      className={`flex items-center justify-center border-[2px] ${selected ? 'border-pink' : 'border-beige-primary'} rounded-full cursor-pointer`}
+      style={{ width: size, height: size }}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+    >
+      {selected && (
+        <div
+          className="bg-pink rounded-full"
+          style={{ width: innerCircleSize, height: innerCircleSize }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default RadioButton;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #39 

## 🔑 주요 변경 사항
### 💎 체크 버튼, 라디오 버튼 컴포넌트 구현
- 공통 체크 버튼 및 라디오 버튼 컴포넌트를 작성했습니다.
- 체크 버튼의 경우 `rounded` props를 통해 모서리의 둥글기를 선택할 수 있어요.
- 두 컴포넌트의 사용 예시는 스토리북에 함께 작성하였으니, 참고해 주세요.

### 🧪 컴포넌트 테스트
- 두 컴포넌트가 예상대로 동작하는지 검증하기 위해 간단한 컴포넌트 테스트를 작성했습니다.

## 📸 스크린 샷
<img width="150" alt="image" src="https://github.com/user-attachments/assets/2b211ce7-fdec-42e0-aaf6-fb50cc0f0b9a" />
<img width="150" alt="image" src="https://github.com/user-attachments/assets/1adf237b-fc06-4699-80be-7de3b849f96c" />

## 💬 TO REVIEWERS
- 접근성 규칙을 준수하는 게 까다로웠어요! 특히 `role`, `aria-checked`, `aria-label` 속성을 적절하게 사용하는 데에 애를 좀 먹었습니다. 😅 (`label`을 따로 받지 않는 컴포넌트라, 차라리 `role`을 `button`으로 설정하는 게 맞는 건가 싶기도 해요.)

- 해당 컴포넌트의 스토리 파일을 작성하면서 `tags: ['autodocs']`를 적용해 보았습니다. 이것을 기반으로 스토리 작성 템플릿을 마련해 보면 좋을 것 같아요.