### PR TITLE
Fix/#51: 좋아요 버튼 수정 및 기능 추가

### DIFF
--- a/src/components/LikeButton/LikeButton.stories.tsx
+++ b/src/components/LikeButton/LikeButton.stories.tsx
@@ -1,0 +1,60 @@
+import { Meta, StoryObj } from '@storybook/react';
+import LikeButton from '@components/LikeButton';
+import '@styles/tailwind.css';
+
+const meta: Meta<typeof LikeButton> = {
+  title: 'Components/LikeButton',
+  component: LikeButton,
+  tags: ['autodocs'],
+  parameters: {
+    docs: { description: { component: '좋아요를 표시하는 버튼입니다.' } },
+  },
+  argTypes: {
+    liked: {
+      control: 'boolean',
+      description: '나의 "좋아요" 여부',
+      table: {
+        type: { summary: 'boolean' },
+      },
+    },
+    count: {
+      control: 'number',
+      description: '전체 "좋아요" 수',
+      table: {
+        type: { summary: 'number' },
+      },
+    },
+    countDisplay: {
+      control: 'boolean',
+      description: '"좋아요" 수 표시 여부',
+      table: { summary: 'boolean' },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof LikeButton>;
+
+export const Default: Story = {
+  args: {
+    liked: false,
+    count: 9999,
+    countDisplay: true,
+  },
+};
+
+export const AlreadyLiked: Story = {
+  args: {
+    liked: true,
+    count: 121,
+    countDisplay: true,
+  },
+};
+
+export const HiddenCount: Story = {
+  args: {
+    liked: false,
+    count: 150,
+    countDisplay: false,
+  },
+};

--- a/src/components/LikeButton/LikeButton.test.tsx
+++ b/src/components/LikeButton/LikeButton.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import LikeButton from '@components/LikeButton';
+
+describe('LikeButton Component', () => {
+  test('좋아요가 비활성화된 상태 확인', () => {
+    render(<LikeButton count={100} liked={false} />);
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    const button = screen.getByRole('button');
+    const heartIconSvg = button.querySelector('svg');
+    expect(heartIconSvg).toHaveAttribute('fill', 'none');
+  });
+
+  test('좋아요가 활성화된 상태 확인', () => {
+    render(<LikeButton count={100} liked />);
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    const button = screen.getByRole('button');
+    const heartIconSvg = button.querySelector('svg');
+    expect(heartIconSvg).toHaveAttribute('fill', '#FF80A6');
+  });
+
+  test('좋아요 수 증가 확인', () => {
+    render(<LikeButton count={100} liked={false} />);
+
+    const button = screen.getByRole('button');
+    const heartIconSvg = button.querySelector('svg');
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(screen.getByText('101')).toBeInTheDocument();
+    expect(heartIconSvg).toHaveAttribute('fill', '#FF80A6');
+  });
+
+  test('좋아요 수 감소 확인', () => {
+    render(<LikeButton count={100} liked />);
+
+    const button = screen.getByRole('button');
+    const heartIconSvg = button.querySelector('svg');
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(screen.getByText('99')).toBeInTheDocument();
+    expect(heartIconSvg).toHaveAttribute('fill', 'none');
+  });
+
+  test('countDisplay=false 일 때 좋아요 개수가 표시되지 않음 확인', () => {
+    render(<LikeButton count={100} liked={false} countDisplay={false} />);
+
+    expect(screen.queryByText('100')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/LikeButton/index.tsx
+++ b/src/components/LikeButton/index.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import HeartIcon from '@assets/icons/heart.svg?react';
+import formatPeopleCount from '@utils/formatPeopleCount';
+
+const LikeButton = ({
+  liked = false,
+  count,
+  countDisplay = true,
+}: {
+  liked?: boolean;
+  count: number;
+  countDisplay?: boolean;
+}) => {
+  const [isLiked, setIsLiked] = useState(liked);
+  const [likeCount, setLikeCount] = useState(count);
+
+  const handleLikeToggle = () => {
+    if (isLiked) {
+      setLikeCount((prev) => prev - 1);
+      setIsLiked(false);
+    } else {
+      setLikeCount((prev) => prev + 1);
+      setIsLiked(true);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-end max-w-[48px]">
+      {countDisplay && (
+        <div className="text-[9px] font-medium text-pink tracking-[-0.5px] mr-[4px]">
+          {formatPeopleCount(likeCount)}
+        </div>
+      )}
+      <button type="button" onClick={handleLikeToggle}>
+        <HeartIcon
+          fill={isLiked ? '#FF80A6' : 'none'}
+          stroke={isLiked ? '#FF80A6' : '#EBD8CB'}
+        />
+      </button>
+    </div>
+  );
+};
+export default LikeButton;

--- a/src/components/MarketProfileCard/MarketProfileCard.test.tsx
+++ b/src/components/MarketProfileCard/MarketProfileCard.test.tsx
@@ -5,7 +5,7 @@ import MOCK_MARKET_PROFILES from '@mocks/constants/mockMarketProfiles';
 
 describe('MarketProfileCard Component', () => {
   it('좋아요 버튼 클릭 시 색상이 변경된다.', () => {
-    render(<MarketProfileCard {...MOCK_MARKET_PROFILES[0]} />);
+    render(<MarketProfileCard {...MOCK_MARKET_PROFILES[1]} />);
     const likeButton = screen.getByRole('button');
     const heartIcon = likeButton.querySelector('svg');
 
@@ -29,7 +29,7 @@ describe('MarketProfileCard Component', () => {
 
     fireEvent.click(likeButton);
     expect(
-      screen.getByText((profile.likes + 1).toString()),
+      screen.getByText((profile.likes - 1).toString()),
     ).toBeInTheDocument();
 
     fireEvent.click(likeButton);

--- a/src/components/MarketProfileCard/index.tsx
+++ b/src/components/MarketProfileCard/index.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import MarketProfileCardProps from '@type/MarketProfileCard';
 import RateIcon from '@assets/icons/rate.svg?react';
-import HeartIcon from '@assets/icons/heart.svg?react';
-import formatPeopleCount from '@utils/formatPeopleCount';
+import LikeButton from '@components/LikeButton';
 
 const ThumbnailList = ({
   thumbnailUrls,
@@ -98,38 +97,13 @@ const ProfileInfo = ({
   </div>
 );
 
-const LikeButton = ({ likes }: { likes: number }) => {
-  const [isLiked, setIsLiked] = useState(false);
-  const [likeCount, setLikeCount] = useState(likes);
-
-  const handleLikeToggle = () => {
-    setIsLiked((prev) => {
-      setLikeCount((prevLikes) => (prev ? prevLikes - 1 : prevLikes + 1));
-      return !prev;
-    });
-  };
-
-  return (
-    <div className="flex items-center">
-      <div className="text-[9px] font-medium text-pink tracking-[-0.5px] mr-[4px]">
-        {formatPeopleCount(likeCount)}
-      </div>
-      <button type="button" onClick={handleLikeToggle}>
-        <HeartIcon
-          fill={isLiked ? '#FF80A6' : 'none'}
-          stroke={isLiked ? '#FF80A6' : '#EBD8CB'}
-        />
-      </button>
-    </div>
-  );
-};
-
 const MarketProfileCard: React.FC<MarketProfileCardProps> = ({
   profileImageUrl,
   marketName,
   description,
   thumbnailUrls,
   rating,
+  liked,
   likes,
 }) => {
   return (
@@ -141,7 +115,7 @@ const MarketProfileCard: React.FC<MarketProfileCardProps> = ({
           description={description}
           rating={rating}
         />
-        <LikeButton likes={likes} />
+        <LikeButton liked={liked} count={likes} />
       </div>
       <ThumbnailList thumbnailUrls={thumbnailUrls} marketName={marketName} />
     </div>

--- a/src/mocks/constants/mockMarketProfiles.ts
+++ b/src/mocks/constants/mockMarketProfiles.ts
@@ -11,6 +11,7 @@ const MOCK_MARKET_PROFILES = [
       'https://images.unsplash.com/photo-1613929231151-d7571591259e?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     ],
     rating: 4.9,
+    liked: true,
     likes: 987,
   },
   {

--- a/src/types/MarketProfileCard.ts
+++ b/src/types/MarketProfileCard.ts
@@ -5,5 +5,6 @@ export default interface MarketProfileCardProps {
   description: string;
   thumbnailUrls: string[];
   rating: number;
+  liked?: boolean;
   likes: number;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #51 

## 🔑 주요 변경 사항
* LikeButton을 공통 컴포넌트로 활용할 수 있도록 하였고, 테스트와 스토리북을 추가했습니다.
* 개발 모드에서 LikeButton 클릭 시 2가 증가하는 버그를 수정하였습니다.
    * strictMode에서 상태 업데이트의 순수성 확인을 위해 updater 함수가 두번 실행되는데, 
    상태 업데이트를 조건문으로 분리하여 해결하였습니다.
* LikeButton 클릭 시 '좋아요' 수에 따라 하트아이콘(SVG)의 위치가 이동하지 않도록 하였습니다.
* 이전에 눌렀던 '좋아요'를 표시할 수 있도록 Prop에 liked를 추가했습니다.
* countDisplay를 통해 LikeButton의 '좋아요' 숫자 표시 여부를 선택하도록 하였습니다. 

## 📸 스크린 샷
![스크린샷 2025-03-20 오후 6 59 52](https://github.com/user-attachments/assets/e4360b3f-f369-4a1c-8dcb-e3bd52dbd040)

## 📖 참고 사항

```
setIsLiked((prev) => {
  setLikeCount((prevLikes) => (prev ? prevLikes - 1 : prevLikes + 1));
  return !prev;
});
```
기존 setIsLiked의 경우 비동기 업데이트 혹은 updater 함수가 여러 번 호출되는 경우에 잘못된 상태로 업데이트 될 수 있어요!
(Strict Mode의 경우 상태 업데이트의 순수성을 확인하기 위해 updater 함수를 두번 실행합니다.)

```
const handleLikeToggle = () => {
    if (isLiked) {
      setLikeCount((prev) => prev - 1);
      setIsLiked(false);
    } else {
      setLikeCount((prev) => prev + 1);
      setIsLiked(true);
    }
  };
```
해당 오류를 해결하기 위해 상태 업데이트를 중첩하지 않고 조건문을 통해 상태 업데이트를 분리하여 해결했습니다.

리액트 공식 문서의 useState 부분에서도 확인 하실 수 있습니다.
🔗[초기화함수 또는 업데이터 함수가 두번 실행됩니다](https://ko.react.dev/reference/react/useState#my-initializer-or-updater-function-runs-twice)