### PR TITLE
Fix/#50: 하단 시트 동작 개선

### DIFF
--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -22,7 +22,6 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
 
   const mouseStartRef = useRef(false);
   const sheetRef = useRef<HTMLDivElement | null>(null);
-  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     const handleScrollLock = () => {
@@ -41,17 +40,6 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
       }
     };
   }, [isBottomSheetOpen, lockBodyScroll, unlockBodyScroll]);
-
-  useEffect(() => {
-    if (isBottomSheetOpen) {
-      lastFocusedElementRef.current = document.activeElement as HTMLElement;
-      setTimeout(() => {
-        sheetRef.current?.focus();
-      }, 10);
-    } else {
-      lastFocusedElementRef.current?.focus();
-    }
-  }, [isBottomSheetOpen]);
 
   const startDrag = (event: React.PointerEvent) => {
     dragControls.start(event);

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -20,6 +20,7 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
   const dragControls = useDragControls();
   const { lockBodyScroll, unlockBodyScroll } = useBodyScrollLock();
 
+  const mouseStartRef = useRef(false);
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
@@ -66,13 +67,42 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
     }
   };
 
+  const handlePointerDownOnSheet = () => {
+    mouseStartRef.current = true;
+  };
+
+  useEffect(() => {
+    const handlePointerUp = () => {
+      setTimeout(() => {
+        mouseStartRef.current = false;
+      }, 0);
+    };
+
+    if (isBottomSheetOpen) {
+      document.addEventListener('pointerup', handlePointerUp);
+    }
+
+    return () => {
+      document.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isBottomSheetOpen]);
+
+  const handleOverlayClick = (e: React.MouseEvent) => {
+    if (mouseStartRef.current) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
+    closeModal(sheetKey);
+  };
+
   return createPortal(
     <AnimatePresence>
       {isBottomSheetOpen && (
         <motion.div
           data-testid="bottom-sheet-overlay"
           className="z-1 fixed inset-0 bg-black/30 flex justify-center items-end"
-          onClick={() => closeModal(sheetKey)}
+          onClick={handleOverlayClick}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -82,6 +112,7 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
             ref={sheetRef}
             tabIndex={-1}
             className="bg-background w-full max-w-[480px] rounded-t-2xl p-[8px] origin-bottom"
+            onPointerDown={handlePointerDownOnSheet}
             onClick={(e) => e.stopPropagation()}
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
@@ -91,7 +122,7 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
             dragControls={dragControls}
             dragListener={false}
             dragConstraints={{ top: 0, bottom: 100 }}
-            dragElastic={0.5}
+            dragElastic={{ top: 0 }}
             onDragEnd={handleDragEnd}
             dragSnapToOrigin
           >

--- a/src/components/BottomSheet/index.tsx
+++ b/src/components/BottomSheet/index.tsx
@@ -1,7 +1,13 @@
-import useModal from '@hooks/useModal';
-import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import {
+  AnimatePresence,
+  motion,
+  PanInfo,
+  useDragControls,
+} from 'framer-motion';
+import useModal from '@hooks/useModal';
+import useBodyScrollLock from '@hooks/useBodyScrollLock';
 
 interface BottomSheetProps {
   sheetKey: string;
@@ -11,9 +17,29 @@ interface BottomSheetProps {
 const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
   const { isModalOpen, closeModal } = useModal();
   const isBottomSheetOpen = isModalOpen(sheetKey);
+  const dragControls = useDragControls();
+  const { lockBodyScroll, unlockBodyScroll } = useBodyScrollLock();
 
   const sheetRef = useRef<HTMLDivElement | null>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    const handleScrollLock = () => {
+      if (isBottomSheetOpen) {
+        lockBodyScroll();
+      } else {
+        unlockBodyScroll();
+      }
+    };
+
+    handleScrollLock();
+
+    return () => {
+      if (isBottomSheetOpen) {
+        unlockBodyScroll();
+      }
+    };
+  }, [isBottomSheetOpen, lockBodyScroll, unlockBodyScroll]);
 
   useEffect(() => {
     if (isBottomSheetOpen) {
@@ -25,6 +51,20 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
       lastFocusedElementRef.current?.focus();
     }
   }, [isBottomSheetOpen]);
+
+  const startDrag = (event: React.PointerEvent) => {
+    dragControls.start(event);
+  };
+
+  const handleDragEnd = (
+    // @ts-expect-error: onDragEnd의 시그니처와 일치시키기 위해 남겨둠
+    event: MouseEvent | TouchEvent | PointerEvent,
+    info: PanInfo,
+  ) => {
+    if (info.offset.y > 50) {
+      closeModal(sheetKey);
+    }
+  };
 
   return createPortal(
     <AnimatePresence>
@@ -41,27 +81,26 @@ const BottomSheet = ({ sheetKey, children }: BottomSheetProps) => {
           <motion.div
             ref={sheetRef}
             tabIndex={-1}
-            className="bg-background w-full max-w-md rounded-t-2xl p-[8px] origin-bottom"
+            className="bg-background w-full max-w-[480px] rounded-t-2xl p-[8px] origin-bottom"
             onClick={(e) => e.stopPropagation()}
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
             exit={{ y: '100%' }}
             transition={{ duration: 0.2, ease: 'easeOut' }}
             drag="y"
+            dragControls={dragControls}
+            dragListener={false}
             dragConstraints={{ top: 0, bottom: 100 }}
-            dragElastic={0}
-            onDragEnd={(_, info) => {
-              if (info.offset.y > 50) closeModal(sheetKey);
-            }}
+            dragElastic={0.5}
+            onDragEnd={handleDragEnd}
+            dragSnapToOrigin
           >
-            <div className="flex justify-center items-center mb-[12px]">
-              <button
-                type="button"
-                aria-label="닫기"
-                data-testid="bottom-sheet-close-button"
-                className="w-[40px] h-[4px] bg-beige-primary rounded-full cursor-pointer"
-                onClick={() => closeModal(sheetKey)}
-              />
+            <div
+              data-testid="bottom-sheet-close-button"
+              className="flex justify-center items-center pt-[4px] p-[12px]"
+              onPointerDown={startDrag}
+            >
+              <div className="w-[40px] h-[4px] bg-beige-primary rounded-full cursor-pointer" />
             </div>
             {children}
           </motion.div>

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,27 @@
+import { useCallback, useRef } from 'react';
+
+const useBodyScrollLock = () => {
+  const scrollPositionRef = useRef<number>(0);
+
+  const lockBodyScroll = useCallback(() => {
+    scrollPositionRef.current = window.scrollY;
+
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+    document.body.style.top = `-${scrollPositionRef.current}px`;
+    document.body.style.overflow = 'hidden';
+  }, []);
+
+  const unlockBodyScroll = useCallback(() => {
+    document.body.style.position = '';
+    document.body.style.width = '';
+    document.body.style.top = '';
+    document.body.style.overflow = '';
+
+    window.scrollTo(0, scrollPositionRef.current);
+  }, []);
+
+  return { lockBodyScroll, unlockBodyScroll };
+};
+
+export default useBodyScrollLock;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #50 

## 🔑 주요 변경 사항
### 🔒 하단 시트 활성화 시 `body` 영역의 스크롤을 비활성화
- 하단 시트에 스크롤 발생 시, `body`의 스크롤과 충돌하거나 겹치는 문제가 발생했습니다.
- `useBodyScrollLock`을 정의하여 하단 시트 활성화 시 `body` 영역의 스크롤을 비활성화하고, 하단 시트가 닫힐 때 다시 원래대로 복원하도록 했습니다.
```TypeScript
import { useCallback, useRef } from 'react';

const useBodyScrollLock = () => {
  const scrollPositionRef = useRef<number>(0);

  const lockBodyScroll = useCallback(() => {
    scrollPositionRef.current = window.scrollY;

    document.body.style.position = 'fixed';
    document.body.style.width = '100%';
    document.body.style.top = `-${scrollPositionRef.current}px`;
    document.body.style.overflow = 'hidden';
  }, []);

  const unlockBodyScroll = useCallback(() => {
    document.body.style.position = '';
    document.body.style.width = '';
    document.body.style.top = '';
    document.body.style.overflow = '';

    window.scrollTo(0, scrollPositionRef.current);
  }, []);

  return { lockBodyScroll, unlockBodyScroll };
};

export default useBodyScrollLock;
```

- `lockBodyScroll`: 스크롤 위치를 저장하고, `body`에 고정된 위치 스타일을 적용하여 스크롤을 막습니다.
- `unlockBodyScroll`: 저장된 스크롤 위치로 페이지를 스크롤하고, `body`의 스타일을 원래대로 되돌립니다.

### 👆슬라이딩 드로어 방식 수정
- 기존 하단 시트는 전체 영역에서 드래그 제스처를 통해 시트를 닫을 수 있었습니다. 하지만 모바일 환경에서 스크롤과 드래그 동작이 충돌하는 문제가 발생했습니다.
- 핸들러를 누른 상태에서만 시트를 드래그하여 닫을 수 있도록 수정하여, 모바일 환경에서의 스크롤과 드래그 동작 간의 충돌을 방지했습니다.

### 👨‍🔧 오버레이 영역에서 드래그 종료 시 하단 시트가 닫히는 문제 수정
- 하단 시트 영역 내부를 클릭한 상태로 오버레이 영역으로 드래그하여 클릭을 해제했을 때, 하단 시트가 닫히는 문제가 있었습니다.

```TypeScript
const mouseStartRef = useRef(false);

const handlePointerDownOnSheet = () => {
  mouseStartRef.current = true;
};

useEffect(() => {
  const handlePointerUp = () => {
    setTimeout(() => {
      mouseStartRef.current = false;
    }, 0);
  };

  if (isBottomSheetOpen) {
    document.addEventListener('pointerup', handlePointerUp);
  }

  return () => {
    document.removeEventListener('pointerup', handlePointerUp);
  };
}, [isBottomSheetOpen]);

const handleOverlayClick = (e: React.MouseEvent) => {
  if (mouseStartRef.current) {
    e.preventDefault();
    e.stopPropagation();
    return;
  }
  closeModal(sheetKey);
};

```

- `mouseStartRef`를 추가하여 포인터 이벤트의 시작 여부를 추적하고, 이를 바탕으로 드래그 시작 후 포인터가 해제될 때 오버레이 클릭 이벤트를 무효화하도록 했습니다.
- 오버레이 클릭 시 `mouseStartRef.current`가 `true`이면 클릭 이벤트를 방지하고, `false`일 경우 시트를 닫도록 처리했습니다.
- 드래그 종료 후 포인터를 떼면 `mouseStartRef.current`를 `false`로 설정하여, 이후의 오버레이 클릭 이벤트가 정상적으로 처리되도록 했습니다.