### PR TITLE
Fix: Vite 설정 파일 내 Vitest 타입 정의 문제 해결

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,13 @@
 /// <reference types="vitest/config" />
-import { defineConfig } from 'vite';
+import { defineConfig, UserConfig } from 'vite';
+import { InlineConfig } from 'vitest/node';
 import react from '@vitejs/plugin-react';
 import svgrPlugin from 'vite-plugin-svgr';
 import path from 'path';
+
+interface VitestConfigExport extends UserConfig {
+  test: InlineConfig;
+}
 
 export default defineConfig({
   plugins: [react(), svgrPlugin()],
@@ -29,4 +34,4 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
   },
-});
+} as VitestConfigExport);


### PR DESCRIPTION
## 📌 관련 이슈
- closes #58 

## 🔑 주요 변경 사항
- Vite 구성 파일 내 `test` 속성을 추가했습니다.
