### PR TITLE
Feature/#63: 소셜 로그인 및 토큰 인증 로직 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ dist-ssr
 *.sw?
 
 *storybook.log
+
+.env
+.vite/

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ dist-ssr
 
 .env
 .vite/
+
+localhost-key.pem
+localhost.pem

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@tailwindcss/postcss": "latest",
+    "axios": "^1.9.0",
     "framer-motion": "^12.4.2",
     "jotai": "^2.12.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.1.5",
-    "tailwindcss": "latest"
+    "tailwindcss": "latest",
+    "vite-plugin-mkcert": "^1.17.8"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import useAxiosInterceptor from '@hooks/useAxiosInterceptor';
+import apiClient from '@apis/apiClient';
 import Home from '@pages/Home';
 import Category from '@pages/Category';
 import Search from '@pages/Search';
@@ -9,21 +11,30 @@ import Cart from '@pages/Cart';
 import Login from '@pages/Login';
 import BottomTab from '@components/BottomTab';
 
+const AxiosInterceptorWrapper: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  useAxiosInterceptor(apiClient);
+  return <>{children}</>;
+};
+
 const App: React.FC = () => {
   return (
     <Router>
-      <div className="app-container">
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/category" element={<Category />} />
-          <Route path="/search" element={<Search />} />
-          <Route path="/wish" element={<Wish />} />
-          <Route path="/my" element={<My />} />
-          <Route path="/cart" element={<Cart />} />
-          <Route path="/login" element={<Login />} />
-        </Routes>
-        <BottomTab />
-      </div>
+      <AxiosInterceptorWrapper>
+        <div className="app-container">
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/category" element={<Category />} />
+            <Route path="/search" element={<Search />} />
+            <Route path="/wish" element={<Wish />} />
+            <Route path="/my" element={<My />} />
+            <Route path="/cart" element={<Cart />} />
+            <Route path="/login" element={<Login />} />
+          </Routes>
+          <BottomTab />
+        </div>
+      </AxiosInterceptorWrapper>
     </Router>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Search from '@pages/Search';
 import Wish from '@pages/Wish';
 import My from '@pages/My';
 import Cart from '@pages/Cart';
+import Login from '@pages/Login';
 import BottomTab from '@components/BottomTab';
 
 const App: React.FC = () => {
@@ -19,6 +20,7 @@ const App: React.FC = () => {
           <Route path="/wish" element={<Wish />} />
           <Route path="/my" element={<My />} />
           <Route path="/cart" element={<Cart />} />
+          <Route path="/login" element={<Login />} />
         </Routes>
         <BottomTab />
       </div>

--- a/src/apis/apiClient.ts
+++ b/src/apis/apiClient.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
+
+const apiClient = axios.create({
+  baseURL: SERVER_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default apiClient;

--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -60,8 +60,7 @@ const useAxiosInterceptor = (instance: AxiosInstance) => {
                 withCredentials: true,
               },
             );
-            const newAccessToken = refreshResponse.data.accessToken;
-            console.log(newAccessToken);
+            const newAccessToken = refreshResponse.data.content.accessToken;
             localStorage.setItem('accessToken', newAccessToken);
 
             if (error.config) {

--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -1,0 +1,115 @@
+import { useEffect, useCallback } from 'react';
+import {
+  AxiosInstance,
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+interface AuthorizationErrorResponse {
+  errorCode: string;
+  message: string;
+}
+
+interface AuthorizationError extends AxiosError {
+  response?: AxiosResponse<AuthorizationErrorResponse>;
+}
+
+const useAxiosInterceptor = (instance: AxiosInstance) => {
+  const navigate = useNavigate();
+
+  const handleRequest = useCallback(
+    async (config: InternalAxiosRequestConfig) => {
+      const accessToken = localStorage.getItem('accessToken');
+      const newConfig = { ...config };
+
+      if (accessToken && newConfig.headers) {
+        newConfig.headers.Authorization = `Bearer ${accessToken}`;
+      }
+
+      return newConfig;
+    },
+    [],
+  );
+
+  const handleResponse = useCallback((response: AxiosResponse) => {
+    return response;
+  }, []);
+
+  const handleError = useCallback(
+    async (error: AuthorizationError) => {
+      const { response } = error;
+
+      if (response && response.data) {
+        const { errorCode } = response.data;
+        if (
+          errorCode === 'REFRESH_INVALID' ||
+          errorCode === 'REFRESH_EXPIRED'
+        ) {
+          navigate('/login');
+          return Promise.reject(error);
+        }
+
+        if (errorCode === 'ACCESS_INVALID' || errorCode === 'ACCESS_EXPIRED') {
+          try {
+            const refreshResponse = await instance.post(
+              '/api/user/reissue',
+              null,
+              {
+                withCredentials: true,
+              },
+            );
+            const newAccessToken = refreshResponse.data.accessToken;
+            console.log(newAccessToken);
+            localStorage.setItem('accessToken', newAccessToken);
+
+            if (error.config) {
+              const newConfig = { ...error.config };
+              newConfig.headers = newConfig.headers || {};
+              newConfig.headers.Authorization = `Bearer ${newAccessToken}`;
+              return instance(newConfig);
+            }
+          } catch (refreshError) {
+            navigate('/login');
+            return Promise.reject(refreshError);
+          }
+        }
+      }
+
+      return Promise.reject(error);
+    },
+    [navigate, instance],
+  );
+
+  const setupInterceptors = useCallback(() => {
+    const requestInterceptor = instance.interceptors.request.use(
+      handleRequest,
+      handleError,
+    );
+    const responseInterceptor = instance.interceptors.response.use(
+      handleResponse,
+      handleError,
+    );
+
+    return { requestInterceptor, responseInterceptor };
+  }, [instance, handleRequest, handleResponse, handleError]);
+
+  const ejectInterceptors = useCallback(
+    (requestInterceptor: number, responseInterceptor: number) => {
+      instance.interceptors.request.eject(requestInterceptor);
+      instance.interceptors.response.eject(responseInterceptor);
+    },
+    [instance],
+  );
+
+  useEffect(() => {
+    const { requestInterceptor, responseInterceptor } = setupInterceptors();
+
+    return () => {
+      ejectInterceptors(requestInterceptor, responseInterceptor);
+    };
+  }, [setupInterceptors, ejectInterceptors]);
+};
+
+export default useAxiosInterceptor;

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -9,7 +9,48 @@ const DividerWithText = ({ text }: { text: string }) => (
   </div>
 );
 
+type OAuthProvider = 'kakao' | 'google' | 'naver';
+
+const SERVER_URL = import.meta.env.VITE_APP_SERVER_URL;
+
+const openOAuthPopup = (provider: OAuthProvider) => {
+  window.open(
+    `${SERVER_URL}/oauth2/authorization/${provider}`,
+    `${provider}-login`,
+    'width=600,height=800',
+  );
+
+  return new Promise<string | null>((resolve) => {
+    const listener = (event: MessageEvent) => {
+      if (event.origin !== SERVER_URL) return;
+
+      const { accessToken } = event.data;
+
+      if (accessToken) {
+        resolve(accessToken);
+      } else {
+        resolve(null);
+      }
+
+      window.removeEventListener('message', listener);
+    };
+
+    window.addEventListener('message', listener);
+  });
+};
+
 const Login = () => {
+  const handleLoginClick = async (provider: OAuthProvider) => {
+    try {
+      const token = await openOAuthPopup(provider);
+      if (token) {
+        localStorage.setItem('accessToken', token);
+      }
+    } catch (err) {
+      // console.error('로그인 중 에러 발생:', err);
+    }
+  };
+
   return (
     <div className="flex flex-col min-h-dvh items-center p-[36px] justify-between">
       <div className="flex flex-col items-center mt-[96px] mb-[24px]">
@@ -22,11 +63,14 @@ const Login = () => {
         </div>
       </div>
       <div className="flex flex-col w-full items-center justify-center gap-[20px] mb-[90px]">
-        <LoginButton type="kakao" onClick={() => {}} />
+        <LoginButton type="kakao" onClick={() => handleLoginClick('kakao')} />
         <DividerWithText text="또는" />
         <div className="flex justify-center gap-[24px]">
-          <LoginButton type="google" onClick={() => {}} />
-          <LoginButton type="naver" onClick={() => {}} />
+          <LoginButton
+            type="google"
+            onClick={() => handleLoginClick('google')}
+          />
+          <LoginButton type="naver" onClick={() => handleLoginClick('naver')} />
         </div>
         <div className="text-[14px] text-brown-tertiary underline tracking-[-0.5px] cursor-pointer">
           비회원으로 주문하셨나요?

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,9 @@
 import { defineConfig, UserConfig } from 'vite';
 import { InlineConfig } from 'vitest/node';
 import react from '@vitejs/plugin-react';
+import fs from 'fs';
 import svgrPlugin from 'vite-plugin-svgr';
+import mkcert from 'vite-plugin-mkcert';
 import path from 'path';
 
 interface VitestConfigExport extends UserConfig {
@@ -10,7 +12,13 @@ interface VitestConfigExport extends UserConfig {
 }
 
 export default defineConfig({
-  plugins: [react(), svgrPlugin()],
+  server: {
+    https: {
+      key: fs.readFileSync(path.resolve(__dirname, 'localhost-key.pem')),
+      cert: fs.readFileSync(path.resolve(__dirname, 'localhost.pem')),
+    },
+  },
+  plugins: [react(), svgrPlugin(), mkcert()],
   resolve: {
     alias: [
       { find: '@apis', replacement: path.resolve(__dirname, 'src/apis') },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4017,16 +4017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.15.6":
-  version: 1.15.9
-  resolution: "follow-redirects@npm:1.15.9"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 859e2bacc7a54506f2bf9aacb10d165df78c8c1b0ceb8023f966621b233717dab56e8d08baadc3ad3b9db58af290413d585c999694b7c146aaf2616340c3d2a6
-  languageName: node
-  linkType: hard
-
 "fondant-frontend@workspace:.":
   version: 0.0.0-use.local
   resolution: "fondant-frontend@workspace:."
@@ -4048,7 +4038,6 @@ __metadata:
     "@types/react": ^18.3.12
     "@types/react-dom": ^18.3.1
     "@vitejs/plugin-react": ^4.3.3
-    axios: ^1.9.0
     eslint: 8.57.0
     eslint-config-airbnb: ^19.0.4
     eslint-config-airbnb-typescript: ^18.0.0
@@ -4099,7 +4088,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0, form-data@npm:^4.0.1":
+"form-data@npm:^4.0.1":
   version: 4.0.2
   resolution: "form-data@npm:4.0.2"
   dependencies:
@@ -6000,13 +5989,6 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
-  languageName: node
-  linkType: hard
-
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2579,6 +2579,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.9.0":
+  version: 1.9.0
+  resolution: "axios@npm:1.9.0"
+  dependencies:
+    follow-redirects: ^1.15.6
+    form-data: ^4.0.0
+    proxy-from-env: ^1.1.0
+  checksum: 631f02c9c279f2ae90637a4989cc9d75c1c27aefd16b6e8eb90f98a4d0bddaccfd1cb1387be12101d1ab0f9bbf0c47e2451b4de0cf2870462a7d9ed3de8da3f2
+  languageName: node
+  linkType: hard
+
 "axobject-query@npm:^4.1.0":
   version: 4.1.0
   resolution: "axobject-query@npm:4.1.0"
@@ -4006,6 +4017,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.6":
+  version: 1.15.9
+  resolution: "follow-redirects@npm:1.15.9"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: 859e2bacc7a54506f2bf9aacb10d165df78c8c1b0ceb8023f966621b233717dab56e8d08baadc3ad3b9db58af290413d585c999694b7c146aaf2616340c3d2a6
+  languageName: node
+  linkType: hard
+
 "fondant-frontend@workspace:.":
   version: 0.0.0-use.local
   resolution: "fondant-frontend@workspace:."
@@ -4027,6 +4048,7 @@ __metadata:
     "@types/react": ^18.3.12
     "@types/react-dom": ^18.3.1
     "@vitejs/plugin-react": ^4.3.3
+    axios: ^1.9.0
     eslint: 8.57.0
     eslint-config-airbnb: ^19.0.4
     eslint-config-airbnb-typescript: ^18.0.0
@@ -4077,7 +4099,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.1":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.1":
   version: 4.0.2
   resolution: "form-data@npm:4.0.2"
   dependencies:
@@ -5978,6 +6000,13 @@ __metadata:
     object-assign: ^4.1.1
     react-is: ^16.13.1
   checksum: c056d3f1c057cb7ff8344c645450e14f088a915d078dcda795041765047fa080d38e5d626560ccaac94a4e16e3aa15f3557c1a9a8d1174530955e992c675e459
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 관련 이슈  
- closes #63  

## 🔑 주요 변경 사항

### 🔐 소셜 로그인 API 연동
- `/oauth2/authorization/{provider}` 경로를 통해 카카오 등 소셜 로그인 OAuth 인증 팝업을 호출합니다.  
- 인증 완료 시, 서버에서 클라이언트로 `postMessage`를 통해 access token을 전달합니다.  
- 클라이언트는 전달받은 토큰을 `localStorage`에 저장하여 이후 인증 요청에 사용합니다.

### 🔁 인증 토큰 자동 처리 및 재발급
- 모든 요청에 access token을 자동으로 포함하며, 만료 시 `/api/user/reissue`를 통해 갱신 요청을 보냅니다.
- 토큰 재발급에 성공하면 새로운 access token을 저장하고, 실패한 요청을 자동 재시도합니다.
- refresh token도 만료된 경우에는 로그아웃 처리 및 로그인 페이지(`/login`)로 이동시킵니다.

### 🌐 전역 Axios 인터셉터 적용
- `useAxiosInterceptor` 훅을 정의하여 요청 시 자동으로 `Authorization` 헤더를 추가합니다.
- 응답 오류 발생 시 토큰 만료 여부를 판단하고, 자동 재발급 및 재요청 처리를 수행합니다.
- `App.tsx`에 `AxiosInterceptorWrapper`를 추가하여 앱 전역에 인터셉터가 적용되도록 구성하였습니다.

### 🪪 개발 서버 HTTPS 적용
- httpOnly 쿠키 통신을 위해 개발 서버에 HTTPS를 적용하였습니다.
- `mkcert`를 사용하여 자체 서명 인증서(`localhost.pem`, `localhost-key.pem`)를 생성하였고,  
  해당 파일은 `.gitignore`에 추가하였습니다.
- `vite.config.ts`에 HTTPS 관련 설정을 반영하였습니다.

## 📖 참고 사항

> `apiClient`를 사용하면 다음과 같이 별도의 토큰 설정 없이 인증 요청을 간편하게 보낼 수 있습니다.

```TypeScript
import apiClient from '@apis/apiClient';

const fetchUserInformation = async () => {
  try {
    const response = await apiClient.get('/api/user');
    const user = response.data.content;

    console.log('유저 정보:', user);
    alert(`이름: ${user.name}\n이메일: ${user.email}`);
  } catch (error) {
    console.error('유저 정보 요청 실패:', error);
    alert('유저 정보를 불러오지 못했습니다.');
  }
};
```